### PR TITLE
Parser: preliminary end-of-line format fixes

### DIFF
--- a/dictionary/dictionary_test.go
+++ b/dictionary/dictionary_test.go
@@ -37,7 +37,7 @@ func TestDictionariesContainExpectedContent(t *testing.T) {
 		GrammaticalAspect: "pl.",
 		Information:       "",
 		Definitions: []string{
-			"ålderdom.  \" tiill aller da[gha] \" MD (S) 242 . oppa sina aldher dagha  Lg 3: 650 .",
+			"ålderdom.  \" tiill aller da[gha] \" MD (S) 242 . oppa sina aldher dagha  Lg 3: 650.",
 		},
 		AlternativeForms: []string{
 			"aller- )",
@@ -50,7 +50,7 @@ func TestDictionariesContainExpectedContent(t *testing.T) {
 		GrammaticalAspect: "adj.",
 		Information:       "",
 		Definitions: []string{
-			" Jfr ofiädhradher.",
+			"Jfr ofiädhradher.",
 		},
 		AlternativeForms: []string{},
 	}
@@ -61,7 +61,7 @@ func TestDictionariesContainExpectedContent(t *testing.T) {
 		GrammaticalAspect: "",
 		Information:       "",
 		Definitions: []string{
-			" , se lund.",
+			", se lund.",
 		},
 		AlternativeForms: []string{},
 	}

--- a/dictionary/parser.go
+++ b/dictionary/parser.go
@@ -12,6 +12,23 @@ func parseRawDictionary(rawDictionary []byte) rawDictionaryEntries {
 	return rawEntries
 }
 
+func formatMalformatted(entryLine string) string {
+	formatted := entryLine
+	// Search-replace the problematic encoding.
+	formatted = strings.Replace(formatted, "&quot;", "\"", -1)
+
+	// Trim trailing whitespaces & odd period structures.
+	formatted = strings.TrimSpace(formatted)
+
+	// Trim oddly spaced periods.
+	if len(formatted) > 3 && string(formatted[len(formatted)-2:]) == " ." {
+		formatted = strings.TrimRight(formatted, " .")
+		formatted = formatted + "."
+	}
+
+	return formatted
+}
+
 func parseDictionary(rawEntries rawDictionaryEntries) []DictionaryEntry {
 	var entries []DictionaryEntry
 
@@ -35,10 +52,12 @@ func parseDictionary(rawEntries rawDictionaryEntries) []DictionaryEntry {
 	}
 
 	// Some formatting tags are encoded in less-than-ideal way.
-	// Search-replace the problematic ones.
 	for idx, entry := range entries {
 		for defIdx, definition := range entry.Definitions {
-			entries[idx].Definitions[defIdx] = strings.Replace(definition, "&quot;", "\"", -1)
+			entries[idx].Definitions[defIdx] = formatMalformatted(definition)
+		}
+		for altIdx, alternativeForm := range entry.AlternativeForms {
+			entries[idx].AlternativeForms[altIdx] = formatMalformatted(alternativeForm)
 		}
 	}
 


### PR DESCRIPTION
There is more work to be done, but should handle trims & odd periods. There seem to be similar cases for commas and other chars.

Closes #20